### PR TITLE
Help concordance find libconcord and use libtool to link

### DIFF
--- a/concordance/Makefile.am
+++ b/concordance/Makefile.am
@@ -1,9 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 bin_PROGRAMS = concordance
 concordance_SOURCES = concordance.c
-concordance_LDFLAGS = $(LIBCONCORD_LDFLAGS)
+concordance_LDADD = ../libconcord/libconcord.la
 # -Wall just makes good sense
-concordance_CFLAGS = -Wall
+concordance_CFLAGS = -Wall -I../libconcord
 man1_MANS = concordance.1
 
 win32-installer:

--- a/concordance/configure.ac
+++ b/concordance/configure.ac
@@ -5,19 +5,6 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_LIBTOOL
 AC_PROG_CXX
 AC_CANONICAL_HOST
-LIBCONCORD_VERSION="4"
-case $host_os in
-  darwin*)
-    LIBCONCORD_LDFLAGS="-lconcord.$LIBCONCORD_VERSION"
-    ;;
-  mingw*)
-    LIBCONCORD_LDFLAGS="-l:libconcord-$LIBCONCORD_VERSION.dll -lwsock32"
-    ;;
-  *)
-    LIBCONCORD_LDFLAGS="-l:libconcord.so.$LIBCONCORD_VERSION"
-    ;;
-esac
-AC_SUBST([LIBCONCORD_LDFLAGS], [$LIBCONCORD_LDFLAGS])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
  Makefile


### PR DESCRIPTION
Fixes long-standing annoyance of having to override CFLAGS and LDFLAGS to tell
concordance how to find libconcord and also removes platform specific code for
linking, leaving this to libtool.

Signed-off-by: Scott Talbert swt@techie.net
