### PR TITLE
Fix various warnings

### DIFF
--- a/libconcord/bindings/python/setup.py
+++ b/libconcord/bindings/python/setup.py
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='libconcord',

--- a/libconcord/libconcord.cpp
+++ b/libconcord/libconcord.cpp
@@ -1169,7 +1169,7 @@ int write_config_to_file(uint8_t *in, uint32_t size, char *file_name,
             ri.flash_mfg, ri.flash_id, ri.hw_ver_major, ri.hw_ver_minor,
             ri.fw_type, ri.config_bytes_used, chk);
         of.write(reinterpret_cast<uint8_t*>(ch), chlen);
-        free(ch);
+        delete[] ch;
     }
 
     of.write(in, ri.config_bytes_used);

--- a/libconcord/usblan.cpp
+++ b/libconcord/usblan.cpp
@@ -34,6 +34,7 @@
 #define closesocket close
 #define SOCKET int
 #define SOCKET_ERROR -1
+#define INVALID_SOCKET -1
 #endif
 
 #ifdef __FreeBSD__
@@ -43,7 +44,7 @@
 #include "libconcord.h"
 #include "lc_internal.h"
 
-static SOCKET sock = SOCKET_ERROR;
+static SOCKET sock = INVALID_SOCKET;
 
 const char * const remote_ip_address = "169.254.1.2";
 const uint16_t remote_port = 3074;
@@ -65,7 +66,7 @@ int ShutdownUsbLan(void)
     int err=0;
 
     // Close the socket
-    if (sock != SOCKET_ERROR) {
+    if (sock != INVALID_SOCKET) {
         if ((err = closesocket(sock))) {
             report_net_error("closesocket()");
             return LC_ERROR_OS_NET;


### PR DESCRIPTION
* Ensure new-allocated memory is freed with delete
* Replace deprecated distutils with setuptools for Python bindings
* Fix signed/unsigned comparison issue on Windows