### PR TITLE
Use HTTPS when communicating with harmonyremote.com

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get install libhidapi-dev libzip-dev
+      run: sudo apt-get install libcurl4-openssl-dev libhidapi-dev libzip-dev
     - name: Build libconcord
       run: |
         cd libconcord

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: dnf install -y autoconf automake diffutils libtool mingw32-gcc-c++ mingw32-hidapi mingw32-libzip
+      run: dnf install -y autoconf automake diffutils libtool mingw32-curl mingw32-gcc-c++ mingw32-hidapi mingw32-libzip
     - name: Build libconcord
       run: |
         cd libconcord

--- a/libconcord/INSTALL.linux
+++ b/libconcord/INSTALL.linux
@@ -7,7 +7,7 @@ source, see the instructions below.
 
 0. INSTALL REQUIRED SOFTWARE
 
-You *MUST* install libusb and libzip. These libraries are in most
+You *MUST* install libusb, libzip, and libcurl. These libraries are in most
 distributions, so apt-get/yum/up2date/urpmi/etc. it.
 
 You also need hidapi which can be found at: https://github.com/signal11/hidapi
@@ -29,8 +29,8 @@ Also, if you are using 900/1000/1100 remotes, then dnsmasq is a requirement,
 as well as installing the udev support files for libconcord (see below).
 
 If you're compiling libconcord from source, you'll also need the development
-packages - usually libusb-dev or libusb-devel (and libzip-dev/libzip-devel),
-depending on your distribution.
+packages - usually libusb-dev or libusb-devel (also libzip-dev/libzip-devel
+and libcurl-dev/libcurl-devel), depending on your distribution.
 
 1. BUILD LIBCONCORD
 

--- a/libconcord/INSTALL.windows
+++ b/libconcord/INSTALL.windows
@@ -43,6 +43,13 @@ release) and then:
   make
   make install
 
+LIBCURL
+In Fedora, simply install mingw32-curl.
+
+For other distributions, including building on Windows directly, grab the
+source from https://curl.se/download.html and follow the instructions for
+building and installing it to /tmp/buildroot.
+
 1. BUILD THE SOFTWARE
 
 Building libconcord with MinGW is also fairly straight forward.

--- a/libconcord/Makefile.am
+++ b/libconcord/Makefile.am
@@ -7,7 +7,7 @@ libconcord_la_SOURCES = remote.cpp remote_z.cpp libconcord.cpp binaryfile.cpp \
 	operationfile.cpp remote_mh.cpp libusbhid.cpp libhidapi.cpp
 include_HEADERS = libconcord.h
 libconcord_la_CPPFLAGS = -Wall
-libconcord_la_LDFLAGS = -version-info 5:0:0 $(LIBCONCORD_LDFLAGS) -lzip
+libconcord_la_LDFLAGS = -version-info 5:0:0 $(LIBCONCORD_LDFLAGS) -lzip -lcurl
 libconcord_la_CXXFLAGS = $(ZIP_CFLAGS)
 UDEVROOT ?= /
 UDEVLIBDIR ?= $(UDEVROOT)/lib

--- a/libconcord/configure.ac
+++ b/libconcord/configure.ac
@@ -85,6 +85,7 @@ then
   AC_MSG_ERROR([$errorstr])
 fi
 PKG_CHECK_MODULES([ZIP], [libzip])
+PKG_CHECK_MODULES([CURL], [libcurl])
 AC_CONFIG_FILES([
     Makefile
 ])

--- a/libconcord/xml_headers.h
+++ b/libconcord/xml_headers.h
@@ -131,13 +131,7 @@ const char *config_header="\
 
 const char *mh_config_header = "<DATA><FILES><FILE NAME=\"Result.EzHex\" SIZE=\"%i\" PATH=\"/cfg/usercfg\" VERSION=\"1\" FW_VERSION=\"9.5\" OPERATIONTYPE=\"userconfiguration\"><CHECKSUM SEED=\"0x4321\" OFFSET=\"0x0\" LENGTH=\"0x%04x\" EXPECTEDVALUE=\"0x%04x\" TYPE=\"XOR\"/></FILE></FILES><INTENDED><SKIN>%i</SKIN></INTENDED><ORDER><ORDER_ELEMENT NAME=\"Result.EzHex\" RESET=\"true\"/></ORDER></DATA>";
 
-const char *post_header="\
-POST /%s HTTP/1.1\r\n\
-User-Agent: HarmonyBrowser/7.3.0 (Build 15; UpdatedFrom 7.3.0.15; Skin logitech; Windows XP 5.1; x86; en; rv: 1.8.0.2) Gecko/20060125\r\n\
-Content-Type:  application/x-www-form-urlencoded\r\n\
-Host: %s\r\n\
-Cookie: %s\r\n\
-Content-Length: %i\r\n\r\n";
+const char* user_agent = "HarmonyBrowser/7.3.0 (Build 15; UpdatedFrom 7.3.0.15; Skin logitech; Windows XP 5.1; x86; en; rv: 1.8.0.2) Gecko/20060125";
 
 const char *post_xml="\
 <EASYZAPPERDATA>\


### PR DESCRIPTION
Recently, Logitech enabled HTTPS on the members.harmonyremote.com
website and implemented automatic redirects from HTTP -> HTTPS.
Unfortunately, this broke our relatively simple HTTP client as it
understood neither redirects nor HTTPS.  Resolve this situation by
replacing our HTTP client with libcurl.  Although this adds a new
dependency, this seems much simpler than trying to implement & maintain the
relevant OpenSSL (or other SSL library) calls to perform HTTPS (which
would also require other dependencies anyway) and also reduces the
codebase slightly.