### PR TITLE
Fix Windows CI test for invoking concordance.exe

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,4 +43,6 @@ jobs:
     - name: Install and test
       run: |
         ${{steps.download.outputs.download-path}}\concordance-installer.exe /S
-        "C:\Program Files (x86)\Concordance\concordance.exe --version"
+        Start-Sleep -Seconds 5
+        cd "C:\Program Files (x86)\Concordance"
+        .\concordance.exe --version


### PR DESCRIPTION
Apparently the silent install happens in the background, so delay a bit
to ensure it is finished.