### PR TITLE
Migrate supported models docs into the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Concordance
 
 This software allows you to program your Logitech Harmony remote using a
-configuration object retrieved from the harmony website:
-  https://members.harmonyremote.com/EasyZapper/New/ProcLogin/Start.asp?BrowserIsChecked=True
+configuration object retrieved from the [harmony
+website](https://members.harmonyremote.com/EasyZapper/New/ProcLogin/Start.asp?BrowserIsChecked=True)
 
 The website is required. The website is required in Logitech's software as
 well, it's just that their software wraps the website. Their website has
@@ -101,8 +101,8 @@ need to use sudo or be root.
 
 5. Write firmware
 
-  NOTE: This feature is only implemented for certain models. Please see:
-    http://www.phildev.net/concordance/supported_models.shtml
+  NOTE: This feature is only implemented for certain models. Please see
+    [supported models](SupportedModels.md)
 
   However for models we support this on, it works like this:
 
@@ -118,8 +118,10 @@ need to use sudo or be root.
 
 There are other options - check out the --help one!
 
+## Related Software
 
-THIS SOFTWARE IS NOT SUPPORTED BY OR IN ANY WAY RELATED TO LOGITECH!
+* [Congruity](https://github.com/congruity/congruity) is a cross-platform graphical front-end for libconcord written in python
 
+## Disclaimer
 
-vim:textwidth=78:
+*THIS SOFTWARE IS NOT SUPPORTED BY OR IN ANY WAY RELATED TO LOGITECH!*

--- a/SupportedModels.md
+++ b/SupportedModels.md
@@ -1,0 +1,26 @@
+# Supported Models
+
+The following is a table of models and their known working status.
+
+Don't see your model? We may have missed one. Just give it a shot, and if you run into a problem, [file an issue](https://github.com/jaymzh/concordance/issues)!
+
+# Legend</h3>
+
+* Working - Fully functionaly, no known (major) problems
+* Believed Working - We believe this works, but need confirmation
+* Almost Working - The functionality is not yet available, but we feel it should be soon
+* Not Working - Not functional
+
+| Arch | Models | Config Update | Learn IR | Firmware Update | Comments |
+|---|---|---|---|---|---|
+| 2 | 745 | Working | Working | Not working | |
+| 3 | 748<br/> 768 | Working | Working | Working | |
+| 7 | 6xx | Working | Working | Working | |
+| 8 | 720<br/>785<br/>88x<br/>AV-100<br/>TC30 | Working | Working | Working | |
+| 9 | 36x<br/>51x<br/>52x<br/>55x | Working | Working | Working | |
+| 10 | 890<br/>895 | Working | Not working | Not working | |
+| 12 | One | Working | Working | Not working | |
+| 14 | 700 | Working | Believed working | Not working | Needs kernel > 2.6.37 |
+| 15 | 900<br/>1000<br/>1000i<br/>1100<br/>Xbox | Working | Not working | Not working | Not yet supported on Mac |
+| 16 | 200<br/>300 | Working | Working | Not working | |
+| 17 | Link | Working | Working | Not working | |


### PR DESCRIPTION
Migrate supported models docs into the repo. I'm killing the little "webpage" for Concordance and letting the GH repo be the site for it. This is the only thing that was not already documented in the repo.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/jaymzh/concordance/pull/49).
* __->__ #49
