### PR TITLE
Add pyproject.toml for the Python bindings (and fix CI)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -4,9 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
-      run: sudo apt-get install libcurl4-openssl-dev libhidapi-dev libzip-dev
+      run: |
+        sudo apt-get install libcurl4-openssl-dev libhidapi-dev libzip-dev
+        pip install build
     - name: Build libconcord
       run: |
         cd libconcord
@@ -19,7 +21,8 @@ jobs:
     - name: Build libconcord Python bindings
       run: |
         cd libconcord/bindings/python
-        sudo python3 setup.py install
+        python3 -m build
+        pip install dist/*.whl
         python3 -c 'import libconcord; print(libconcord)'
         cd -
     - name: Build concordance

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -4,9 +4,11 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
-      run: brew install autoconf automake hidapi libzip
+      run: |
+        brew install autoconf automake hidapi libzip
+        pip3 install build
     - name: Build libconcord
       run: |
         cd libconcord
@@ -18,7 +20,8 @@ jobs:
     - name: Build libconcord Python bindings
       run: |
         cd libconcord/bindings/python
-        sudo python3 setup.py install
+        python3 -m build
+        pip3 install dist/*.whl
         python3 -c 'import libconcord; print(libconcord)'
         cd -
     - name: Build concordance

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,7 +22,7 @@ jobs:
         cd libconcord/bindings/python
         python3 -m build
         pip3 install dist/*.whl
-        python3 -c 'import libconcord; print(libconcord)'
+        DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib python3 -c 'import libconcord; print(libconcord)'
         cd -
     - name: Build concordance
       run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: dnf install -y autoconf automake diffutils libtool mingw32-curl mingw32-gcc-c++ mingw32-hidapi mingw32-libzip mingw32-nsis python3-pip python3-wheel
     - name: Build libconcord
@@ -28,7 +28,7 @@ jobs:
       run: |
         pip install mingw-ldd
         MINGW_SYSROOT_BIN="/usr/i686-w64-mingw32/sys-root/mingw/bin" concordance/win/make_installer.py
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: windows-installer
         path: concordance/win/concordance-installer.exe
@@ -36,7 +36,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       id: download
       with:
         name: windows-installer

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: dnf install -y autoconf automake diffutils libtool mingw32-curl mingw32-gcc-c++ mingw32-hidapi mingw32-libzip mingw32-nsis python3-pip python3-wheel
+      run: dnf install -y autoconf automake diffutils libtool mingw32-curl mingw32-gcc-c++ mingw32-hidapi mingw32-libstdc++ mingw32-libzip mingw32-nsis python3-pip python3-wheel
     - name: Build libconcord
       run: |
         cd libconcord

--- a/libconcord/bindings/python/pyproject.toml
+++ b/libconcord/bindings/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is needed for modern Python building/packaging (ie, invoking
setup.py directly is now deprecated).

Closes #51.