### PR TITLE
Update Windows CI to use up/download-artifact v4

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install mingw-ldd
         MINGW_SYSROOT_BIN="/usr/i686-w64-mingw32/sys-root/mingw/bin" concordance/win/make_installer.py
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: windows-installer
         path: concordance/win/concordance-installer.exe
@@ -39,7 +39,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download
       with:
         name: windows-installer


### PR DESCRIPTION
v3 seems to be unsupported anymore and causing the CI to fail.