### PR TITLE
Windows: 64-Bit, use schannel for curl

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,27 +11,73 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install dependencies
-      run: dnf install -y autoconf automake diffutils libtool mingw32-curl mingw32-gcc-c++ mingw32-hidapi mingw32-libstdc++ mingw32-libzip mingw32-nsis python3-pip python3-wheel
+      run: |
+        # We have to install mingw32-nsis even though we're building a 64-bit installer. We've configured nsis to produce a 64-bit exe
+        dnf install -y autoconf automake diffutils fedpkg libtool mingw64-gcc-c++ mingw64-hidapi mingw64-libstdc++ mingw64-libzip mingw32-nsis mingw64-nsis mingw64-libpsl mingw64-libidn2 python3-pip python3-wheel
+    - name: Prep libcurl
+      run: |
+        mkdir mingw-curl
+        cd mingw-curl
+        dnf download mingw-curl --source
+        rpm2cpio *.src.rpm | cpio -idmv
+        cp mingw-curl.spec mingw-curl.original_spec
+        sed -i -f ../concordance/win/mingw-curl-spec-changes.sed mingw-curl.spec
+        cd -
+    - uses: actions/upload-artifact@v7
+      with:
+        name: src-spec
+        path: |
+          mingw-curl/*.spec
+          mingw-curl/*.original_spec
+    - name: Restore libcurl from cache (if available)
+      id: restore-curl
+      uses: actions/cache/restore@v5
+      with:
+        path: mingw-curl/noarch/*.rpm
+        key: libcurl-mingw64-schannel-${{ hashFiles('mingw-curl/*.spec') }}
+    - name: Build libcurl if it wasn't in the cache
+      if: steps.restore-curl.outputs.cache-hit != 'true'
+      run: |
+        cd mingw-curl
+        dnf -y builddep mingw-curl.spec
+        fedpkg local
+        cd -
+# Explicit save/restore so that if libcurl compiles, it is cached and reused even if concordance/libconcord fail
+    - name: Save libcurl to cache
+      if: steps.restore-curl.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: mingw-curl/noarch/*.rpm
+        key: libcurl-mingw64-schannel-${{ hashFiles('mingw-curl/*.spec') }}
+    - uses: actions/upload-artifact@v7
+      with:
+        name: src-rpm
+        path: mingw-curl/*.rpm
+    - uses: actions/upload-artifact@v7
+      with:
+        name: bin-rpms
+        path: mingw-curl/noarch/*.rpm
     - name: Build libconcord
       run: |
+        rpm -i mingw-curl/noarch/*.rpm
         cd libconcord
         mkdir m4; autoreconf --install
-        mingw32-configure
-        mingw32-make
-        mingw32-make install
+        mingw64-configure
+        mingw64-make
+        mingw64-make install
         cd -
     - name: Build concordance
       run: |
         cd concordance
         mkdir m4; autoreconf --install
-        mingw32-configure LDFLAGS="$(rpm -E %{mingw32_ldflags}) -L$(rpm -E %{mingw32_bindir})"
-        mingw32-make
-        mingw32-make install
+        mingw64-configure LDFLAGS="$(rpm -E %{mingw64_ldflags}) -L$(rpm -E %{mingw64_bindir})"
+        mingw64-make
+        mingw64-make install
         cd -
     - name: Build installer
       run: |
         pip install mingw-ldd
-        MINGW_SYSROOT_BIN="/usr/i686-w64-mingw32/sys-root/mingw/bin" concordance/win/make_installer.py
+        MINGW_SYSROOT_BIN="/usr/x86_64-w64-mingw32/sys-root/mingw/bin" concordance/win/make_installer.py
     - uses: actions/upload-artifact@v7
       with:
         name: windows-installer
@@ -48,5 +94,5 @@ jobs:
       run: |
         ${{steps.download.outputs.download-path}}\concordance-installer.exe /S
         Start-Sleep -Seconds 5
-        cd "C:\Program Files (x86)\Concordance"
+        cd "C:\Program Files\Concordance"
         .\concordance.exe --version

--- a/concordance/win/concordance.nsi
+++ b/concordance/win/concordance.nsi
@@ -11,7 +11,7 @@
 #
 # which will generate the output file 'installer.exe' which is a Windows
 # installer containing your program.
-
+Target amd64-unicode
 Name "Concordance"
 OutFile "concordance-installer.exe"
 InstallDir "$ProgramFiles\Concordance"

--- a/concordance/win/mingw-curl-spec-changes.sed
+++ b/concordance/win/mingw-curl-spec-changes.sed
@@ -1,0 +1,25 @@
+1i %global mingw_build_win32 0
+s/^Release:.*/Release:     99%{?dist}/
+# Enable schannel
+s/^MINGW32_CONFIGURE_ARGS.*//
+s/^MINGW64_CONFIGURE_ARGS.*//
+s/^MINGW_CONFIGURE_ARGS.*/MINGW_CONFIGURE_ARGS="--with-schannel --enable-ipv6 --without-random"/
+# Remove unneeded 64 bit dependencies
+s/^BuildRequires:.*mingw64-libidn2//
+s/^BuildRequires:.*mingw64-libssh2//
+s/^BuildRequires:.*mingw64-openssl//
+# Remove 32 bit since we're only building 64 bit
+/^BuildRequires:.*mingw32/d
+/^%package -n mingw32-curl/,/^Static version of the MinGW Windows Curl library/d
+# Remove 64 bit static, disable debug package
+/^%package -n mingw64-curl-static/,/^%{?mingw_debug_package}/c\%global debug_package %{nil}
+# Remove 32 bit package files
+/^%files -n mingw32-curl/,/^# Win64/c\# Win64
+# Remove 64 bit static files
+/^%files -n mingw64-curl-static/,/^%changelog/c\%changelog
+# Misc remnants
+/MINGW_BUILDDIR_SUFFIX=_static/d
+/mv.*mingw32/d
+/rm.*mingw32/d
+/mv.*static/d
+/rm.*static/d


### PR DESCRIPTION
This is in reference to the SSL certificate issues we identified back in https://github.com/jaymzh/concordance/issues/55 and further elaborated on in https://github.com/congruity/congruity/pull/12#issuecomment-2106298677 . This is what I was referring to in https://github.com/jaymzh/concordance/pull/57#issuecomment-2705045382 (though is independent of the wheel changes etc.)

We found that if we used schannel on Windows for curl, connections to the Logitech site would automatically pull down the appropriate SSL certificates into the certificate store and use them. The prior method discussed in https://github.com/jaymzh/concordance/pull/56 would use the SSL certificates from the store but wouldn't install them if they were missing.

This PR provides two items:
1) Build curl for Windows with --with-schannel, and create an rpm
2) Build concordance using the curl rpm

~~Known improvements that could be made:~~

~~1) Still using Fedora 39 as opposed to latest to compile~~ Fixed
~~2) We could merge the two Windows workflows into one, and not store an RPM in Git~~ Fixed