### PR TITLE
fix: double free

### DIFF
--- a/libconcord/libconcord.cpp
+++ b/libconcord/libconcord.cpp
@@ -763,8 +763,10 @@ int init_concord()
 int deinit_concord()
 {
     ShutdownUSB();
-    if (rmt)
+    if (rmt) {
         delete rmt;
+        rmt = NULL;
+    }
     return 0;
 }
 


### PR DESCRIPTION
happens when deinit_concord() is called by the user code and the class destructor.